### PR TITLE
Claude/push simply drive rebrand z iukh

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,2 @@
-app_identifier("com.simply.drive.app") # bundle identifier
+app_identifier("com.purus.driver") # bundle identifier
 apple_id("") # your Apple ID (optional)

--- a/furfarchApp25001.xcodeproj/project.pbxproj
+++ b/furfarchApp25001.xcodeproj/project.pbxproj
@@ -16,52 +16,52 @@
 			containerPortal = A26AC4942EFF4F0000AC99E4 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = A26AC49B2EFF4F0000AC99E4;
-			remoteInfo = SimplyDrive;
+			remoteInfo = PurusDrive;
 		};
 		A26AC4B82EFF4F0100AC99E4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A26AC4942EFF4F0000AC99E4 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = A26AC49B2EFF4F0000AC99E4;
-			remoteInfo = SimplyDrive;
+			remoteInfo = PurusDrive;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		A26AC49C2EFF4F0000AC99E4 /* SimplyDrive.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SimplyDrive.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		A26AC4AD2EFF4F0100AC99E4 /* SimplyDriveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplyDriveTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		A26AC4B72EFF4F0100AC99E4 /* SimplyDriveUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplyDriveUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A26AC49C2EFF4F0000AC99E4 /* PurusDrive.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PurusDrive.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A26AC4AD2EFF4F0100AC99E4 /* PurusDriveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PurusDriveTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A26AC4B72EFF4F0100AC99E4 /* PurusDriveUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PurusDriveUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2EA6EAB2F02C9E400AECEAF /* CarPhotoPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPhotoPickerView.swift; sourceTree = "<group>"; };
 		A2EA6EAD2F02C9E700AECEAF /* VehiclesViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VehiclesViews.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		A26AC4BF2EFF4F0100AC99E4 /* Exceptions for "SimplyDrive" folder in "SimplyDrive" target */ = {
+		A26AC4BF2EFF4F0100AC99E4 /* Exceptions for "PurusDrive" folder in "PurusDrive" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
-			target = A26AC49B2EFF4F0000AC99E4 /* SimplyDrive */;
+			target = A26AC49B2EFF4F0000AC99E4 /* PurusDrive */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		A26AC49E2EFF4F0000AC99E4 /* SimplyDrive */ = {
+		A26AC49E2EFF4F0000AC99E4 /* PurusDrive */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				A26AC4BF2EFF4F0100AC99E4 /* Exceptions for "SimplyDrive" folder in "SimplyDrive" target */,
+				A26AC4BF2EFF4F0100AC99E4 /* Exceptions for "PurusDrive" folder in "PurusDrive" target */,
 			);
-			path = SimplyDrive;
+			path = PurusDrive;
 			sourceTree = "<group>";
 		};
-		A26AC4B02EFF4F0100AC99E4 /* SimplyDriveTests */ = {
+		A26AC4B02EFF4F0100AC99E4 /* PurusDriveTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			path = SimplyDriveTests;
+			path = PurusDriveTests;
 			sourceTree = "<group>";
 		};
-		A26AC4BA2EFF4F0100AC99E4 /* SimplyDriveUITests */ = {
+		A26AC4BA2EFF4F0100AC99E4 /* PurusDriveUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			path = SimplyDriveUITests;
+			path = PurusDriveUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -94,9 +94,9 @@
 		A26AC4932EFF4F0000AC99E4 = {
 			isa = PBXGroup;
 			children = (
-				A26AC49E2EFF4F0000AC99E4 /* SimplyDrive */,
-				A26AC4B02EFF4F0100AC99E4 /* SimplyDriveTests */,
-				A26AC4BA2EFF4F0100AC99E4 /* SimplyDriveUITests */,
+				A26AC49E2EFF4F0000AC99E4 /* PurusDrive */,
+				A26AC4B02EFF4F0100AC99E4 /* PurusDriveTests */,
+				A26AC4BA2EFF4F0100AC99E4 /* PurusDriveUITests */,
 				A26AC49D2EFF4F0000AC99E4 /* Products */,
 				A2EA6EAB2F02C9E400AECEAF /* CarPhotoPickerView.swift */,
 				A2EA6EAD2F02C9E700AECEAF /* VehiclesViews.swift */,
@@ -106,9 +106,9 @@
 		A26AC49D2EFF4F0000AC99E4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A26AC49C2EFF4F0000AC99E4 /* SimplyDrive.app */,
-				A26AC4AD2EFF4F0100AC99E4 /* SimplyDriveTests.xctest */,
-				A26AC4B72EFF4F0100AC99E4 /* SimplyDriveUITests.xctest */,
+				A26AC49C2EFF4F0000AC99E4 /* PurusDrive.app */,
+				A26AC4AD2EFF4F0100AC99E4 /* PurusDriveTests.xctest */,
+				A26AC4B72EFF4F0100AC99E4 /* PurusDriveUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -116,9 +116,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		A26AC49B2EFF4F0000AC99E4 /* SimplyDrive */ = {
+		A26AC49B2EFF4F0000AC99E4 /* PurusDrive */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A26AC4C02EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "SimplyDrive" */;
+			buildConfigurationList = A26AC4C02EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "PurusDrive" */;
 			buildPhases = (
 				A26AC4982EFF4F0000AC99E4 /* Sources */,
 				A26AC4992EFF4F0000AC99E4 /* Frameworks */,
@@ -129,18 +129,18 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				A26AC49E2EFF4F0000AC99E4 /* SimplyDrive */,
+				A26AC49E2EFF4F0000AC99E4 /* PurusDrive */,
 			);
-			name = SimplyDrive;
+			name = PurusDrive;
 			packageProductDependencies = (
 			);
-			productName = SimplyDrive;
-			productReference = A26AC49C2EFF4F0000AC99E4 /* SimplyDrive.app */;
+			productName = PurusDrive;
+			productReference = A26AC49C2EFF4F0000AC99E4 /* PurusDrive.app */;
 			productType = "com.apple.product-type.application";
 		};
-		A26AC4AC2EFF4F0100AC99E4 /* SimplyDriveTests */ = {
+		A26AC4AC2EFF4F0100AC99E4 /* PurusDriveTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A26AC4C52EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "SimplyDriveTests" */;
+			buildConfigurationList = A26AC4C52EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "PurusDriveTests" */;
 			buildPhases = (
 				A26AC4A92EFF4F0100AC99E4 /* Sources */,
 				A26AC4AA2EFF4F0100AC99E4 /* Frameworks */,
@@ -152,18 +152,18 @@
 				A26AC4AF2EFF4F0100AC99E4 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				A26AC4B02EFF4F0100AC99E4 /* SimplyDriveTests */,
+				A26AC4B02EFF4F0100AC99E4 /* PurusDriveTests */,
 			);
-			name = SimplyDriveTests;
+			name = PurusDriveTests;
 			packageProductDependencies = (
 			);
-			productName = SimplyDriveTests;
-			productReference = A26AC4AD2EFF4F0100AC99E4 /* SimplyDriveTests.xctest */;
+			productName = PurusDriveTests;
+			productReference = A26AC4AD2EFF4F0100AC99E4 /* PurusDriveTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		A26AC4B62EFF4F0100AC99E4 /* SimplyDriveUITests */ = {
+		A26AC4B62EFF4F0100AC99E4 /* PurusDriveUITests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A26AC4C82EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "SimplyDriveUITests" */;
+			buildConfigurationList = A26AC4C82EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "PurusDriveUITests" */;
 			buildPhases = (
 				A26AC4B32EFF4F0100AC99E4 /* Sources */,
 				A26AC4B42EFF4F0100AC99E4 /* Frameworks */,
@@ -175,13 +175,13 @@
 				A26AC4B92EFF4F0100AC99E4 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				A26AC4BA2EFF4F0100AC99E4 /* SimplyDriveUITests */,
+				A26AC4BA2EFF4F0100AC99E4 /* PurusDriveUITests */,
 			);
-			name = SimplyDriveUITests;
+			name = PurusDriveUITests;
 			packageProductDependencies = (
 			);
-			productName = SimplyDriveUITests;
-			productReference = A26AC4B72EFF4F0100AC99E4 /* SimplyDriveUITests.xctest */;
+			productName = PurusDriveUITests;
+			productReference = A26AC4B72EFF4F0100AC99E4 /* PurusDriveUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 /* End PBXNativeTarget section */
@@ -207,7 +207,7 @@
 					};
 				};
 			};
-			buildConfigurationList = A26AC4972EFF4F0000AC99E4 /* Build configuration list for PBXProject "SimplyDrive" */;
+			buildConfigurationList = A26AC4972EFF4F0000AC99E4 /* Build configuration list for PBXProject "PurusDrive" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -221,9 +221,9 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				A26AC49B2EFF4F0000AC99E4 /* SimplyDrive */,
-				A26AC4AC2EFF4F0100AC99E4 /* SimplyDriveTests */,
-				A26AC4B62EFF4F0100AC99E4 /* SimplyDriveUITests */,
+				A26AC49B2EFF4F0000AC99E4 /* PurusDrive */,
+				A26AC4AC2EFF4F0100AC99E4 /* PurusDriveTests */,
+				A26AC4B62EFF4F0100AC99E4 /* PurusDriveUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -280,12 +280,12 @@
 /* Begin PBXTargetDependency section */
 		A26AC4AF2EFF4F0100AC99E4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = A26AC49B2EFF4F0000AC99E4 /* SimplyDrive */;
+			target = A26AC49B2EFF4F0000AC99E4 /* PurusDrive */;
 			targetProxy = A26AC4AE2EFF4F0100AC99E4 /* PBXContainerItemProxy */;
 		};
 		A26AC4B92EFF4F0100AC99E4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = A26AC49B2EFF4F0000AC99E4 /* SimplyDrive */;
+			target = A26AC49B2EFF4F0000AC99E4 /* PurusDrive */;
 			targetProxy = A26AC4B82EFF4F0100AC99E4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -298,7 +298,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				AUTOMATION_APPLE_EVENTS = NO;
-				CODE_SIGN_ENTITLEMENTS = SimplyDrive/SimplyDrive.entitlements;
+				CODE_SIGN_ENTITLEMENTS = PurusDrive/PurusDrive.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -320,7 +320,7 @@
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = SimplyDrive/Info.plist;
+				INFOPLIST_FILE = PurusDrive/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -338,7 +338,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.simply.drive.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.purus.driver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
@@ -370,7 +370,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				AUTOMATION_APPLE_EVENTS = NO;
-				CODE_SIGN_ENTITLEMENTS = SimplyDrive/SimplyDrive.entitlements;
+				CODE_SIGN_ENTITLEMENTS = PurusDrive/PurusDrive.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -392,7 +392,7 @@
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = SimplyDrive/Info.plist;
+				INFOPLIST_FILE = PurusDrive/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -410,7 +410,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.simply.drive.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.purus.driver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
@@ -562,7 +562,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.simply.drive.appTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.purus.driverTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -573,7 +573,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SimplyDrive.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SimplyDrive";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PurusDrive.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PurusDrive";
 				XROS_DEPLOYMENT_TARGET = 26.2;
 			};
 			name = Debug;
@@ -589,7 +589,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.simply.drive.appTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.purus.driverTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -600,7 +600,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SimplyDrive.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SimplyDrive";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PurusDrive.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PurusDrive";
 				XROS_DEPLOYMENT_TARGET = 26.2;
 			};
 			name = Release;
@@ -615,7 +615,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.simply.drive.appUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.purus.driverUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -626,7 +626,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = SimplyDrive;
+				TEST_TARGET_NAME = PurusDrive;
 				XROS_DEPLOYMENT_TARGET = 26.2;
 			};
 			name = Debug;
@@ -641,7 +641,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.simply.drive.appUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.purus.driverUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -652,7 +652,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = SimplyDrive;
+				TEST_TARGET_NAME = PurusDrive;
 				XROS_DEPLOYMENT_TARGET = 26.2;
 			};
 			name = Release;
@@ -660,7 +660,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		A26AC4972EFF4F0000AC99E4 /* Build configuration list for PBXProject "SimplyDrive" */ = {
+		A26AC4972EFF4F0000AC99E4 /* Build configuration list for PBXProject "PurusDrive" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A26AC4C32EFF4F0100AC99E4 /* Debug */,
@@ -669,7 +669,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A26AC4C02EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "SimplyDrive" */ = {
+		A26AC4C02EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "PurusDrive" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A26AC4C12EFF4F0100AC99E4 /* Debug */,
@@ -678,7 +678,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A26AC4C52EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "SimplyDriveTests" */ = {
+		A26AC4C52EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "PurusDriveTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A26AC4C62EFF4F0100AC99E4 /* Debug */,
@@ -687,7 +687,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A26AC4C82EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "SimplyDriveUITests" */ = {
+		A26AC4C82EFF4F0100AC99E4 /* Build configuration list for PBXNativeTarget "PurusDriveUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A26AC4C92EFF4F0100AC99E4 /* Debug */,

--- a/furfarchApp25001.xcodeproj/xcuserdata/cf.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/furfarchApp25001.xcodeproj/xcuserdata/cf.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>SchemeUserState</key>
 	<dict>
-		<key>SimplyDrive.xcscheme_^#shared#^_</key>
+		<key>PurusDrive.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
 			<integer>0</integer>

--- a/furfarchApp25001/AboutView.swift
+++ b/furfarchApp25001/AboutView.swift
@@ -12,7 +12,7 @@ struct AboutView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
 
-                Text("Simply Drive")
+                Text("Purus Drive")
                     .font(.headline)
 
                 Text("\(yearMonth) • Personal Vehicle and Drive Log")

--- a/furfarchApp25001/ExportService.swift
+++ b/furfarchApp25001/ExportService.swift
@@ -210,7 +210,7 @@ enum ExportService {
     private static func fileName(scope: ExportScope, ext: String) -> String {
         let df = DateFormatter()
         df.dateFormat = "yyyyMMdd_HHmmss"
-        return "simplydrive_export_\(scope.rawValue)_\(df.string(from: .now)).\(ext)"
+        return "purusdrive_export_\(scope.rawValue)_\(df.string(from: .now)).\(ext)"
     }
 
     private static func escape(_ s: String) -> String {

--- a/furfarchApp25001/Item.swift
+++ b/furfarchApp25001/Item.swift
@@ -1,6 +1,6 @@
 //
 //  Item.swift
-//  SimplyDrive
+//  Purus Drive
 //
 //  Created by Chris Furfari on 27.12.2025.
 //

--- a/furfarchApp25001/SettingsView.swift
+++ b/furfarchApp25001/SettingsView.swift
@@ -22,7 +22,7 @@ final class CloudStatusViewModel: ObservableObject {
     @Published var isICloudAvailable: Bool = false
 
     func refresh() {
-        CKContainer(identifier: "iCloud.com.simply.drive").accountStatus { [weak self] status, error in
+        CKContainer(identifier: "iCloud.com.purus.driver").accountStatus { [weak self] status, error in
             DispatchQueue.main.async {
                 if let error {
                     self?.accountStatusText = "Error: \(error.localizedDescription)"

--- a/furfarchApp25001/furfarchApp25001App.swift
+++ b/furfarchApp25001/furfarchApp25001App.swift
@@ -1,6 +1,6 @@
 //
-//  SimplyDriveApp.swift
-//  SimplyDrive
+//  PurusDriveApp.swift
+//  Purus Drive
 //
 //  Created by Chris Furfari on 27.12.2025.
 //
@@ -8,7 +8,7 @@
 /*
  App Display Name:
  Set in target -> Info (or Info.plist) as CFBundleDisplayName to:
- "Simply Drive"
+ "Purus Drive"
 */
 
 import SwiftUI
@@ -44,9 +44,9 @@ private struct StorageInitErrorView: View {
 }
 
 @main
-struct SimplyDriveApp: App {
+struct PurusDriveApp: App {
     private static let storageLocationKey = "storageLocation"
-    private static let cloudContainerId = "iCloud.com.simply.drive"
+    private static let cloudContainerId = "iCloud.com.purus.driver"
     private static let localStoreFileName = "default.store"
     private static let cloudStoreFileName = "cloud.store"
 

--- a/furfarchApp25001UITests/furfarchApp25001UITests.swift
+++ b/furfarchApp25001UITests/furfarchApp25001UITests.swift
@@ -1,13 +1,13 @@
 //
-//  SimplyDriveUITests.swift
-//  SimplyDriveUITests
+//  PurusDriveUITests.swift
+//  PurusDriveUITests
 //
 //  Created by Chris Furfari on 27.12.2025.
 //
 
 import XCTest
 
-final class SimplyDriveUITests: XCTestCase {
+final class PurusDriveUITests: XCTestCase {
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/furfarchApp25001UITests/furfarchApp25001UITestsLaunchTests.swift
+++ b/furfarchApp25001UITests/furfarchApp25001UITestsLaunchTests.swift
@@ -1,13 +1,13 @@
 //
-//  SimplyDriveUITestsLaunchTests.swift
-//  SimplyDriveUITests
+//  PurusDriveUITestsLaunchTests.swift
+//  PurusDriveUITests
 //
 //  Created by Chris Furfari on 27.12.2025.
 //
 
 import XCTest
 
-final class SimplyDriveUITestsLaunchTests: XCTestCase {
+final class PurusDriveUITestsLaunchTests: XCTestCase {
 
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
         true


### PR DESCRIPTION
## Summary by Sourcery

Rebrand the app from Simply Drive to Purus Drive across the codebase and associated configuration.

Enhancements:
- Rename the main app type, UI test classes, and user-facing titles from Simply Drive to Purus Drive.
- Update iCloud container identifiers and export filename prefixes to use the new Purus Drive naming.
- Adjust Xcode scheme naming to match the Purus Drive branding.