### PR TITLE
Add version and build number to About view

### DIFF
--- a/PurusDrive/AboutView.swift
+++ b/PurusDrive/AboutView.swift
@@ -8,6 +8,14 @@ struct AboutView: View {
         return formatter.string(from: now)
     }
 
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+    }
+
+    private var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
@@ -17,6 +25,10 @@ struct AboutView: View {
 
                 Text("\(yearMonth) • Personal Vehicle and Drive Log")
                     .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Text("Version \(appVersion) (\(buildNumber))")
+                    .font(.caption)
                     .foregroundStyle(.secondary)
 
                 Divider()


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Show the app's version and build number in the About view.