### PR TITLE
Change aps-environment to production for TestFlight CloudKit sync

### DIFF
--- a/PurusDrive/PurusDrive.entitlements
+++ b/PurusDrive/PurusDrive.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>aps-environment</key>
-	<string>development</string>
+	<string>production</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.purus.driver</string>


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust PurusDrive.entitlements to change environment-related settings for distribution.