### PR TITLE
Add CloudKit sync fixes and in-app diagnostics

### DIFF
--- a/PurusDrive/Info.plist
+++ b/PurusDrive/Info.plist
@@ -10,5 +10,9 @@
 	<string>This app may save photos of vehicles to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app needs access to your photo library to choose vehicle photos.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- Add UIBackgroundModes with remote-notification for CloudKit sync
- Add CloudKitDiagnostics panel in Settings showing:
  - Storage mode (iCloud/Local)
  - Container ID and init status
  - Account status
  - User record ID
  - Private database zones
- Add Copy Diagnostics button for easy sharing
- Capture container creation errors for display

https://claude.ai/code/session_01QWktPF6pMa92xM5huijTE2

## Summary by Sourcery

Add in-app CloudKit diagnostics and improve CloudKit-backed storage initialization robustness.

New Features:
- Expose a CloudKit diagnostics section in Settings showing storage mode, container details, account status, user record ID, and private database zones.
- Provide a Copy Diagnostics action to copy current CloudKit status information to the clipboard.

Bug Fixes:
- Improve CloudKit-backed storage initialization with explicit error capture, user-facing fallback messaging, and diagnostics updates when iCloud storage cannot be opened.

Enhancements:
- Extend CloudKit status view model to surface raw account status, user record ID, and private database zone information for diagnostics.
- Share CloudKit container configuration and initialization results via a global diagnostics helper for use across the app.

Build:
- Declare remote-notification background mode in Info.plist to support CloudKit sync in the background.